### PR TITLE
fix: toctou race condition

### DIFF
--- a/src/jose.c
+++ b/src/jose.c
@@ -303,12 +303,15 @@ void LoadEmb(char *emb_file, real *emb_ptr) {
     exit(1);
   }
   printf("Loading embedding from file %s\n", emb_file);
-  if (access(emb_file, R_OK) == -1) {
+  
+  // check file existence
+  FILE *fp = fopen(emb_file, "r");
+  if (fp == NULL) {
     printf("File %s does not exist\n", emb_file);
     exit(1);
   }
+  
   // read embedding file
-  FILE *fp = fopen(emb_file, "r");
   fscanf(fp, "%d", &vocab_size_tmp);
   fscanf(fp, "%d", &word_dim);
   if (layer1_size != word_dim) {


### PR DESCRIPTION
vulnerability may arise when the file is checked for existence using `access(emb_file, R_OK) == -1`, and then subsequently opened using `fopen(emb_file, "r")`. 

fixing by using `fopen` and handling the case where `fopen` fails.